### PR TITLE
Fix runtime permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,7 @@ RUN mkdir /lib64 && \
 
 COPY --from=builder /go/bin/ /bin/
 
+HEALTHCHECK --interval=5s --timeout=10s --retries=3 \
+  CMD [[ $(/bin/updateservicectl --version) =~ "1.4.0" ]] || exit 1
 
 ENTRYPOINT ["/bin/drone-coreupdate"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,15 +16,9 @@ RUN mkdir /lib64 && \
     ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 && \
     apk update && \
     apk --no-cache -Uuv add curl ca-certificates && \
-    rm -rf /var/cache/apk/* && \
+    rm -rf /var/cache/apk/*
 
-    # Create the user and group files that will be used in the running container to
-    # run the process an unprivileged user.
-    addgroup -g 1000 -S drone && \
-    adduser -u 1000 -S drone -G drone
+COPY --from=builder /go/bin/ /bin/
 
-COPY --chown=drone --from=builder /go/bin/ /bin/
-
-USER drone:drone
 
 ENTRYPOINT ["/bin/drone-coreupdate"]


### PR DESCRIPTION
Due to the nature of volumes being mounted as `root`, if I set a specific user (`drone`) with limited permissions it won't be able to interpolate files accordingly